### PR TITLE
Add transparent PNG generator web tool

### DIFF
--- a/web/transparent-generator/index.html
+++ b/web/transparent-generator/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gerador de PNG Transparente</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="app">
+    <header>
+      <h1>Gerador de PNG Transparente</h1>
+      <p>Crie arquivos PNG totalmente transparentes com proporções personalizadas ou pré-definidas.</p>
+    </header>
+
+    <section class="controls" aria-label="Controles de dimensão">
+      <div class="field">
+        <label for="ratio">Proporção</label>
+        <select id="ratio" aria-describedby="ratioHelp">
+          <option value="custom">Personalizada</option>
+          <option value="16:9">16:9 (1920×1080)</option>
+          <option value="4:3">4:3 (1600×1200)</option>
+          <option value="1:1">1:1 (1080×1080)</option>
+          <option value="9:16">9:16 (1080×1920)</option>
+        </select>
+        <small id="ratioHelp">Escolha uma proporção ou defina suas próprias dimensões.</small>
+      </div>
+
+      <div class="field">
+        <label for="width">Largura (px)</label>
+        <input type="number" id="width" min="1" max="8000" value="1920" aria-describedby="widthHelp">
+        <small id="widthHelp">Valores entre 1 e 8000 pixels.</small>
+      </div>
+
+      <div class="field">
+        <label for="height">Altura (px)</label>
+        <input type="number" id="height" min="1" max="8000" value="1080" aria-describedby="heightHelp">
+        <small id="heightHelp">Valores entre 1 e 8000 pixels.</small>
+      </div>
+
+      <button id="download" type="button" class="download">Baixar PNG</button>
+      <p class="feedback" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="preview" aria-label="Pré-visualização da tela transparente">
+      <h2>Pré-visualização</h2>
+      <div class="preview-frame">
+        <div class="preview-canvas" role="img" aria-label="Pré-visualização das dimensões selecionadas"></div>
+      </div>
+      <p class="dimensions" aria-live="polite">1920 × 1080 px</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>Compatível com navegadores modernos. Nenhum conteúdo é salvo.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/web/transparent-generator/script.js
+++ b/web/transparent-generator/script.js
@@ -1,0 +1,108 @@
+const ratioSelect = document.getElementById('ratio');
+const widthInput = document.getElementById('width');
+const heightInput = document.getElementById('height');
+const downloadBtn = document.getElementById('download');
+const feedback = document.querySelector('.feedback');
+const dimensionsText = document.querySelector('.dimensions');
+const previewCanvas = document.querySelector('.preview-canvas');
+
+const ratioPresets = {
+  '16:9': [1920, 1080],
+  '4:3': [1600, 1200],
+  '1:1': [1080, 1080],
+  '9:16': [1080, 1920]
+};
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+function setAspectRatio(width, height) {
+  const aspect = width / height;
+  previewCanvas.style.setProperty('--aspect', aspect);
+}
+
+function updateDimensionsText(width, height) {
+  dimensionsText.textContent = `${width} × ${height} px`;
+}
+
+function handleRatioChange() {
+  const value = ratioSelect.value;
+  if (value !== 'custom' && ratioPresets[value]) {
+    const [presetWidth, presetHeight] = ratioPresets[value];
+    widthInput.value = presetWidth;
+    heightInput.value = presetHeight;
+  }
+  updatePreview();
+}
+
+function validateInput() {
+  const width = Number(widthInput.value);
+  const height = Number(heightInput.value);
+
+  if (!width || !height) {
+    feedback.textContent = 'Informe valores válidos para largura e altura.';
+    return false;
+  }
+
+  if (width < 1 || height < 1) {
+    feedback.textContent = 'As dimensões devem ser maiores que zero.';
+    return false;
+  }
+
+  if (width > 8000 || height > 8000) {
+    feedback.textContent = 'O tamanho máximo suportado é 8000 × 8000 pixels.';
+    return false;
+  }
+
+  feedback.textContent = '';
+  return true;
+}
+
+function updatePreview() {
+  if (!validateInput()) {
+    return;
+  }
+  const width = Number(widthInput.value);
+  const height = Number(heightInput.value);
+
+  setAspectRatio(width, height);
+  updateDimensionsText(width, height);
+}
+
+function downloadTransparentPNG() {
+  if (!validateInput()) {
+    return;
+  }
+
+  const width = clamp(Math.round(Number(widthInput.value)), 1, 8000);
+  const height = clamp(Math.round(Number(heightInput.value)), 1, 8000);
+
+  widthInput.value = width;
+  heightInput.value = height;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const link = document.createElement('a');
+  link.download = `transparent_${width}x${height}.png`;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+
+  feedback.textContent = 'Arquivo gerado com sucesso!';
+  setTimeout(() => {
+    feedback.textContent = '';
+  }, 2500);
+}
+
+ratioSelect.addEventListener('change', handleRatioChange);
+widthInput.addEventListener('input', () => {
+  ratioSelect.value = 'custom';
+  updatePreview();
+});
+heightInput.addEventListener('input', () => {
+  ratioSelect.value = 'custom';
+  updatePreview();
+});
+downloadBtn.addEventListener('click', downloadTransparentPNG);
+
+document.addEventListener('DOMContentLoaded', updatePreview);

--- a/web/transparent-generator/script.js
+++ b/web/transparent-generator/script.js
@@ -14,67 +14,139 @@ const ratioPresets = {
 };
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const MAX_SIZE = 8000;
+const MAX_PREVIEW_EDGE = 420;
+let isSyncing = false;
 
-function setAspectRatio(width, height) {
+function showFeedback(message = '', isError = false) {
+  feedback.textContent = message;
+  feedback.classList.toggle('error', Boolean(message) && isError);
+  feedback.classList.toggle('success', Boolean(message) && !isError);
+}
+
+function parseDimensions({ report = true } = {}) {
+  const widthRaw = widthInput.value;
+  const heightRaw = heightInput.value;
+
+  if (widthRaw === '' || heightRaw === '') {
+    if (report) {
+      showFeedback('');
+    }
+    return null;
+  }
+
+  const width = Number(widthRaw);
+  const height = Number(heightRaw);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    if (report) {
+      showFeedback('Use apenas números para largura e altura.', true);
+    }
+    return null;
+  }
+
+  if (width <= 0 || height <= 0) {
+    if (report) {
+      showFeedback('As dimensões devem ser maiores que zero.', true);
+    }
+    return null;
+  }
+
+  if (width > MAX_SIZE || height > MAX_SIZE) {
+    if (report) {
+      showFeedback(`O tamanho máximo suportado é ${MAX_SIZE} × ${MAX_SIZE} pixels.`, true);
+    }
+    return null;
+  }
+
+  if (!Number.isInteger(width) || !Number.isInteger(height)) {
+    if (report) {
+      showFeedback('Informe valores inteiros para largura e altura.', true);
+    }
+    return null;
+  }
+
+  if (report) {
+    showFeedback('');
+  }
+
+  return { width, height };
+}
+
+function simplifyRatio(width, height) {
+  const gcd = (a, b) => (b === 0 ? a : gcd(b, a % b));
+  const factor = gcd(width, height) || 1;
+  return `${Math.round(width / factor)}:${Math.round(height / factor)}`;
+}
+
+function setPreviewMetrics(width, height) {
   const aspect = width / height;
   previewCanvas.style.setProperty('--aspect', aspect);
+
+  let previewWidth = MAX_PREVIEW_EDGE;
+  let previewHeight = previewWidth / aspect;
+
+  if (previewHeight > MAX_PREVIEW_EDGE) {
+    previewHeight = MAX_PREVIEW_EDGE;
+    previewWidth = previewHeight * aspect;
+  }
+
+  previewCanvas.style.setProperty('--preview-width', `${previewWidth}px`);
+  previewCanvas.style.setProperty('--preview-height', `${previewHeight}px`);
+  previewCanvas.setAttribute(
+    'aria-label',
+    `Pré-visualização das dimensões selecionadas: ${width} por ${height} pixels`
+  );
 }
 
 function updateDimensionsText(width, height) {
-  dimensionsText.textContent = `${width} × ${height} px`;
+  const ratioText = simplifyRatio(width, height);
+  dimensionsText.textContent = `${width} × ${height} px • proporção ${ratioText}`;
 }
 
-function handleRatioChange() {
-  const value = ratioSelect.value;
-  if (value !== 'custom' && ratioPresets[value]) {
-    const [presetWidth, presetHeight] = ratioPresets[value];
-    widthInput.value = presetWidth;
-    heightInput.value = presetHeight;
-  }
-  updatePreview();
-}
-
-function validateInput() {
-  const width = Number(widthInput.value);
-  const height = Number(heightInput.value);
-
-  if (!width || !height) {
-    feedback.textContent = 'Informe valores válidos para largura e altura.';
-    return false;
+function syncDimension(source) {
+  const preset = ratioPresets[ratioSelect.value];
+  if (!preset || isSyncing) {
+    return;
   }
 
-  if (width < 1 || height < 1) {
-    feedback.textContent = 'As dimensões devem ser maiores que zero.';
-    return false;
-  }
+  const [presetWidth, presetHeight] = preset;
+  const ratio = presetWidth / presetHeight;
 
-  if (width > 8000 || height > 8000) {
-    feedback.textContent = 'O tamanho máximo suportado é 8000 × 8000 pixels.';
-    return false;
+  isSyncing = true;
+  if (source === 'width') {
+    const newWidth = Number(widthInput.value);
+    if (Number.isFinite(newWidth) && newWidth > 0) {
+      heightInput.value = Math.round(newWidth / ratio);
+    }
+  } else if (source === 'height') {
+    const newHeight = Number(heightInput.value);
+    if (Number.isFinite(newHeight) && newHeight > 0) {
+      widthInput.value = Math.round(newHeight * ratio);
+    }
   }
-
-  feedback.textContent = '';
-  return true;
+  isSyncing = false;
 }
 
 function updatePreview() {
-  if (!validateInput()) {
+  const dims = parseDimensions();
+  if (!dims) {
     return;
   }
-  const width = Number(widthInput.value);
-  const height = Number(heightInput.value);
 
-  setAspectRatio(width, height);
+  const { width, height } = dims;
+  setPreviewMetrics(width, height);
   updateDimensionsText(width, height);
 }
 
 function downloadTransparentPNG() {
-  if (!validateInput()) {
+  const dims = parseDimensions();
+  if (!dims) {
     return;
   }
 
-  const width = clamp(Math.round(Number(widthInput.value)), 1, 8000);
-  const height = clamp(Math.round(Number(heightInput.value)), 1, 8000);
+  const width = clamp(dims.width, 1, MAX_SIZE);
+  const height = clamp(dims.height, 1, MAX_SIZE);
 
   widthInput.value = width;
   heightInput.value = height;
@@ -83,26 +155,62 @@ function downloadTransparentPNG() {
   canvas.width = width;
   canvas.height = height;
 
-  const link = document.createElement('a');
-  link.download = `transparent_${width}x${height}.png`;
-  link.href = canvas.toDataURL('image/png');
-  link.click();
+  const filename = `transparent_${width}x${height}.png`;
 
-  feedback.textContent = 'Arquivo gerado com sucesso!';
-  setTimeout(() => {
-    feedback.textContent = '';
-  }, 2500);
+  const exportData = (blob) => {
+    if (!blob) {
+      showFeedback('Não foi possível gerar o arquivo. Tente novamente.', true);
+      return;
+    }
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    requestAnimationFrame(() => URL.revokeObjectURL(url));
+
+    showFeedback(`Arquivo “${filename}” gerado com sucesso!`, false);
+    setTimeout(() => showFeedback(''), 2500);
+  };
+
+  if (canvas.toBlob) {
+    canvas.toBlob(exportData, 'image/png');
+  } else {
+    const dataUrl = canvas.toDataURL('image/png');
+    fetch(dataUrl)
+      .then((response) => response.blob())
+      .then(exportData)
+      .catch(() => showFeedback('Não foi possível gerar o arquivo. Tente novamente.', true));
+  }
+}
+
+function handleRatioChange() {
+  const value = ratioSelect.value;
+  if (value !== 'custom' && ratioPresets[value]) {
+    const [presetWidth, presetHeight] = ratioPresets[value];
+    widthInput.value = presetWidth;
+    heightInput.value = presetHeight;
+    showFeedback('');
+  }
+  updatePreview();
 }
 
 ratioSelect.addEventListener('change', handleRatioChange);
 widthInput.addEventListener('input', () => {
-  ratioSelect.value = 'custom';
+  if (ratioSelect.value !== 'custom') {
+    syncDimension('width');
+  }
   updatePreview();
 });
 heightInput.addEventListener('input', () => {
-  ratioSelect.value = 'custom';
+  if (ratioSelect.value !== 'custom') {
+    syncDimension('height');
+  }
   updatePreview();
 });
 downloadBtn.addEventListener('click', downloadTransparentPNG);
 
-document.addEventListener('DOMContentLoaded', updatePreview);
+updatePreview();

--- a/web/transparent-generator/styles.css
+++ b/web/transparent-generator/styles.css
@@ -1,0 +1,222 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  --bg: #f7f7fa;
+  --text: #121212;
+  --accent: #4a7cf3;
+  --border: rgba(0, 0, 0, 0.1);
+  --card-bg: rgba(255, 255, 255, 0.9);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --text: #f1f5f9;
+    --border: rgba(241, 245, 249, 0.1);
+    --card-bg: rgba(13, 17, 23, 0.85);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  min-height: 100vh;
+  justify-content: center;
+  padding: clamp(1.5rem, 3vw, 3rem);
+}
+
+main.app {
+  width: min(960px, 100%);
+  display: grid;
+  gap: 2rem;
+}
+
+header {
+  text-align: center;
+}
+
+header h1 {
+  font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+@media (prefers-color-scheme: dark) {
+  header p {
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+.controls {
+  display: grid;
+  gap: 1rem;
+  background: var(--card-bg);
+  padding: clamp(1.5rem, 2vw, 2.25rem);
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px -25px rgba(0, 0, 0, 0.4);
+}
+
+.field {
+  display: grid;
+  gap: 0.25rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input[type="number"],
+select {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.85);
+  color: inherit;
+}
+
+input[type="number"]:focus,
+select:focus {
+  outline: 3px solid rgba(74, 124, 243, 0.25);
+  border-color: var(--accent);
+}
+
+small {
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  input[type="number"],
+  select {
+    background: rgba(24, 31, 43, 0.9);
+  }
+
+  small {
+    color: rgba(255, 255, 255, 0.6);
+  }
+}
+
+.download {
+  margin-top: 0.5rem;
+  padding: 0.9rem 1.4rem;
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.download:hover,
+.download:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px -15px var(--accent);
+}
+
+.feedback {
+  min-height: 1.2rem;
+  margin: 0;
+}
+
+.preview {
+  display: grid;
+  gap: 1rem;
+  background: var(--card-bg);
+  padding: clamp(1.5rem, 2vw, 2.25rem);
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px -25px rgba(0, 0, 0, 0.4);
+}
+
+.preview-frame {
+  position: relative;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background: repeating-conic-gradient(
+      rgba(0, 0, 0, 0.08) 0 25%,
+      rgba(0, 0, 0, 0) 0 50%
+    )
+    0 / 20px 20px,
+    rgba(255, 255, 255, 0.7);
+  min-height: 240px;
+  display: grid;
+  place-items: center;
+}
+
+.preview-canvas {
+  width: min(100%, 480px);
+  aspect-ratio: var(--aspect, 16 / 9);
+  border-radius: 0.5rem;
+  border: 2px dashed rgba(0, 0, 0, 0.35);
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.7) 0 10px,
+      rgba(255, 255, 255, 0.1) 10px 20px
+    );
+  transition: aspect-ratio 0.2s ease, width 0.2s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  .preview-frame {
+    background: repeating-conic-gradient(
+        rgba(255, 255, 255, 0.08) 0 25%,
+        rgba(0, 0, 0, 0) 0 50%
+      )
+      0 / 20px 20px,
+      rgba(13, 17, 23, 0.8);
+  }
+
+  .preview-canvas {
+    border-color: rgba(255, 255, 255, 0.35);
+    background: repeating-linear-gradient(
+        45deg,
+        rgba(13, 17, 23, 0.6) 0 10px,
+        rgba(255, 255, 255, 0.1) 10px 20px
+      );
+  }
+}
+
+.dimensions {
+  font-weight: 600;
+  font-size: 1rem;
+  margin: 0;
+}
+
+footer {
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  footer {
+    color: rgba(255, 255, 255, 0.6);
+  }
+}
+
+@media (min-width: 880px) {
+  main.app {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  header {
+    grid-column: span 2;
+  }
+
+  footer {
+    grid-column: span 2;
+  }
+}

--- a/web/transparent-generator/styles.css
+++ b/web/transparent-generator/styles.css
@@ -8,6 +8,8 @@
   --accent: #4a7cf3;
   --border: rgba(0, 0, 0, 0.1);
   --card-bg: rgba(255, 255, 255, 0.9);
+  --success: #166534;
+  --error: #b91c1c;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -16,6 +18,8 @@
     --text: #f1f5f9;
     --border: rgba(241, 245, 249, 0.1);
     --card-bg: rgba(13, 17, 23, 0.85);
+    --success: #34d399;
+    --error: #f87171;
   }
 }
 
@@ -130,6 +134,15 @@ small {
 .feedback {
   min-height: 1.2rem;
   margin: 0;
+  font-weight: 500;
+}
+
+.feedback.error {
+  color: var(--error);
+}
+
+.feedback.success {
+  color: var(--success);
 }
 
 .preview {
@@ -157,7 +170,9 @@ small {
 }
 
 .preview-canvas {
-  width: min(100%, 480px);
+  width: min(100%, var(--preview-width, 420px));
+  max-width: 100%;
+  height: var(--preview-height, auto);
   aspect-ratio: var(--aspect, 16 / 9);
   border-radius: 0.5rem;
   border: 2px dashed rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
## Summary
- create a responsive web interface for generating transparent PNGs with presets and dimensões personalizadas
- add live preview, validação de entradas e feedback de download instantâneo
- aplicar estilo minimalista acessível e adaptável a temas claro/escuro

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e41d808b388322a86a59c7b6e66924